### PR TITLE
add option to always open new tabs in target window

### DIFF
--- a/modules/options.js
+++ b/modules/options.js
@@ -1,7 +1,9 @@
 //@ts-check
 var defaultOptions = {
     openActive: false,
-    shortcutOpenName: null
+    shortcutOpenName: null,
+    shortcutOpen: false,
+    shortcutOpenAlt: false,
 };
 
 /**

--- a/options/options.html
+++ b/options/options.html
@@ -18,10 +18,15 @@
     <br/><br/>
 
     <label>
-        <input type="checkbox" id="shortcut-open-enabled"> Enable Alt-click open shortcut <br/><br/>
-        Name of the Alt-click target <br/>
-        <input type="text" id="shortcut-open-name"> 
+        <input type="checkbox" id="shortcut-open-alt"> Enable Alt-click open shortcut <br/><br/>
     </label>
+
+    <label>
+        <input type="checkbox" id="shortcut-open"> Enable open all new tabs in target window <br/><br/>
+    </label>
+
+    Name of the target window (blank for first window) <br/>
+    <input type="text" id="shortcut-open-name">
 
     <br/><br/><br/>
 

--- a/options/options.js
+++ b/options/options.js
@@ -20,7 +20,18 @@ function openActiveDomElement() {
  * @return {HTMLInputElement} 
  */
 function openShortcutEnabledDomElement() {
-    let element = /** @type {HTMLInputElement} */ (document.getElementById('shortcut-open-enabled'));
+    let element = /** @type {HTMLInputElement} */ (document.getElementById('shortcut-open'));
+
+    return element
+}
+
+/**
+ * Gets the openShortcutAltEnabled checkbox DOM Element
+ * 
+ * @return {HTMLInputElement} 
+ */
+function openShortcutAltEnabledDomElement() {
+    let element = /** @type {HTMLInputElement} */ (document.getElementById('shortcut-open-alt'));
 
     return element
 }
@@ -39,17 +50,10 @@ function openShortcutNameDomElement() {
 document.addEventListener('DOMContentLoaded', function () {
     readOptions(function (items) {
         openActiveDomElement().checked = items.openActive;
-        if (items.shortcutOpenName) {
-            openShortcutEnabledDomElement().checked = true;
-            openShortcutNameDomElement().value = items.shortcutOpenName;
-        }
+        openShortcutEnabledDomElement().checked = items.shortcutOpen;
+        openShortcutAltEnabledDomElement().checked = items.shortcutOpenAlt;
+        openShortcutNameDomElement().value = items.shortcutOpenName;
     });
-
-    openShortcutEnabledDomElement().addEventListener('change', function(evt) {
-        if (!openShortcutEnabledDomElement().checked) {
-            openShortcutNameDomElement().value = "";   
-        }
-    })
 });
 
 document.getElementById('save').addEventListener('click', function () {
@@ -57,22 +61,20 @@ document.getElementById('save').addEventListener('click', function () {
 
     status.textContent = "Save clicked";
 
-    if (openShortcutEnabledDomElement().checked && !openShortcutNameDomElement().value) {
-        status.innerHTML = '<div style="color: red">Name must be set when Alt-click is enabled</div>';
-    } else {
-        saveOptions(
-            {
-                openActive: openActiveDomElement().checked,
-                shortcutOpenName: openShortcutNameDomElement().value
-            },
-            function () {
-                status.textContent = 'Options saved.';
-                
-                setTimeout(function () {
-                    status.textContent = '';
-                }, 750);
-            }
-        );
-        port.postMessage({action: 'options-saved'});
-    }
+    saveOptions(
+        {
+            openActive: openActiveDomElement().checked,
+            shortcutOpenAlt: openShortcutAltEnabledDomElement().value,
+            shortcutOpen: openShortcutEnabledDomElement().value,
+            shortcutOpenName: openShortcutNameDomElement().value
+        },
+        function () {
+            status.textContent = 'Options saved.';
+
+            setTimeout(function () {
+                status.textContent = '';
+            }, 750);
+        }
+    );
+    port.postMessage({action: 'options-saved'});
 });


### PR DESCRIPTION
Recent versions of Chrome have nerfed the "open as app" functionality.  Previously one could invoke Chrome from the command line like this:

```
chromium-browser --app=some-url
```

It would open the url in a popup window without the address bar or tab bar.  Importantly, any links in the appified window that target `_blank` will open a tab in the main window rather than in the appified window.

I guess they're getting rid of that functionality or something?  Now links just sort of open in the appified window, confusing the browser.

This extension was really close to what I wanted, so I added an option to open all new tabs in the main browser window (not just when alt-clicking).  I also added the ability to skip specifying a target name, in which case the lowest-number window ID will be used (in my case, the main browser window).

I'm totally new to extension development, so please let me know if I've missed anything :)